### PR TITLE
Rename key -> pageKey

### DIFF
--- a/Sources/Pagination/Model+Paginatable.swift
+++ b/Sources/Pagination/Model+Paginatable.swift
@@ -12,10 +12,10 @@ import Vapor
 extension Model where Self: Paginatable, Self: Content {
     /// Returns a paginated response on `.all()` entities
     /// using page number from the request data
-    public static func paginate(for req: Request, key: String = Pagination.defaultPageKey, perKey: String = Pagination.defaultPagePerKey, _ sorts: [QuerySort] = Self.defaultPageSorts) throws -> Future<Page<Self>> {
+    public static func paginate(for req: Request, pageKey: String = Pagination.defaultPageKey, perKey: String = Pagination.defaultPagePerKey, _ sorts: [QuerySort] = Self.defaultPageSorts) throws -> Future<Page<Self>> {
         return try Self.query(on: req).paginate(
             for: req,
-            key: key,
+            pageKey: pageKey,
             perKey: perKey,
             sorts
         )

--- a/Sources/Pagination/Model+Paginatable.swift
+++ b/Sources/Pagination/Model+Paginatable.swift
@@ -12,11 +12,11 @@ import Vapor
 extension Model where Self: Paginatable, Self: Content {
     /// Returns a paginated response on `.all()` entities
     /// using page number from the request data
-    public static func paginate(for req: Request, pageKey: String = Pagination.defaultPageKey, perKey: String = Pagination.defaultPagePerKey, _ sorts: [QuerySort] = Self.defaultPageSorts) throws -> Future<Page<Self>> {
+    public static func paginate(for req: Request, pageKey: String = Pagination.defaultPageKey, perPageKey: String = Pagination.defaultPerPageKey, _ sorts: [QuerySort] = Self.defaultPageSorts) throws -> Future<Page<Self>> {
         return try Self.query(on: req).paginate(
             for: req,
             pageKey: pageKey,
-            perKey: perKey,
+            perPageKey: perPageKey,
             sorts
         )
     }

--- a/Sources/Pagination/Pagination.swift
+++ b/Sources/Pagination/Pagination.swift
@@ -6,4 +6,4 @@
 //
 
 public var defaultPageKey = "page"
-public var defaultPagePerKey = "size"
+public var defaultPerPageKey = "per"

--- a/Sources/Pagination/QueryBuilder+Paginatable.swift
+++ b/Sources/Pagination/QueryBuilder+Paginatable.swift
@@ -41,8 +41,8 @@ extension QueryBuilder where Model: Paginatable {
 
 extension QueryBuilder where Model: Paginatable, Model: Content {
     /// Returns a page-based response using page number from the request data
-    public func paginate(for req: Request, key: String = Pagination.defaultPageKey, perKey: String = Pagination.defaultPagePerKey, _ sorts: [QuerySort] = Model.defaultPageSorts) throws -> Future<Page<Model>> {
-        let page = try req.query.get(Int?.self, at: key) ?? 1
+    public func paginate(for req: Request, pageKey: String = Pagination.defaultPageKey, perKey: String = Pagination.defaultPagePerKey, _ sorts: [QuerySort] = Model.defaultPageSorts) throws -> Future<Page<Model>> {
+        let page = try req.query.get(Int?.self, at: pageKey) ?? 1
         var per = try req.query.get(Int?.self, at: perKey) ?? Model.defaultPageSize
         if let maxPer = Model.maxPageSize, per > maxPer {
             per = maxPer


### PR DESCRIPTION
In order to increase clarity and consistency, I propose changing the parameter label `key` to `pageKey` in the `paginate` methods.

## Motivation
The [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/#promote-clear-usage) urges us to *"Include all the words needed to avoid ambiguity"*. By changing `key` to `pageKey` we remove any ambiguity about what `key` is — specifically that it is the page key in the query. 

This also increases consistency throughout the code since everywhere else (see: [`Pagination.defaultPageKey`](https://github.com/vapor-community/pagination/blob/c4d407cd7934ad34e8393af906e44a00c8890184/Sources/Pagination/Pagination.swift#L8)) this key is referred to as the `pageKey`.

## Breaking Change?
Potentially, but not drastic. Since the parameter is provided a default value, unless a user has specified the `key` parameter, there won't be any breaking changes. If, however, they have specified `key` the compiler can automatically suggest the renamed parameter label which makes upgrading trivial.