### PR TITLE
Prevent crashes for `per` values ≤ 0

### DIFF
--- a/Sources/Pagination/Paginatable.swift
+++ b/Sources/Pagination/Paginatable.swift
@@ -11,6 +11,7 @@ import Vapor
 
 public enum PaginationError: Error {
     case invalidPageNumber(Int)
+    case invalidPerSize(Int)
     case unspecified(Error)
 }
 

--- a/Sources/Pagination/QueryBuilder+Paginatable.swift
+++ b/Sources/Pagination/QueryBuilder+Paginatable.swift
@@ -11,9 +11,14 @@ import Vapor
 
 extension QueryBuilder where Result: Paginatable, Result.Database == Database {
     public func paginate(page: Int, per: Int = Result.defaultPageSize, _ sorts: [Result.Database.QuerySort] = Result.defaultPageSorts) throws -> Future<Page<Result>> {
-        // Make sure the current pzge is greater than 0
+        // Make sure the current page is greater than 0
         guard page > 0 else {
             throw PaginationError.invalidPageNumber(page)
+        }
+
+        // Per-page also must be greater than zero
+        guard per > 0 else {
+            throw PaginationError.invalidPerSize(per)
         }
 
         // Require page 1 or greater


### PR DESCRIPTION
This PR quickly fixes a bug in which the Pagination library crashes the entire server due to division by zero.