### PR TITLE
Fixed missing test case

### DIFF
--- a/Tests/PaginationTests/PaginationTests.swift
+++ b/Tests/PaginationTests/PaginationTests.swift
@@ -19,6 +19,16 @@ final class PaginationTests: XCTestCase {
         super.tearDown()
     }
 
+	func testLinuxTestSuiteIncludesAllTests() {
+		#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+		let thisClass = type(of: self)
+		let linuxCount = thisClass.allTests.count
+		let darwinCount = Int(thisClass
+			.defaultTestSuite.testCaseCount)
+		XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from allTests")
+		#endif
+	}
+
     func testQuery() throws {
         let models: [TestModel] = try [
             TestModel.create(name: "Test 1", on: self.sqlConnection),
@@ -51,7 +61,9 @@ final class PaginationTests: XCTestCase {
     }
 
     static var allTests = [
+		("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
         ("testQuery", testQuery),
-        ("testFilterQuery", testFilterQuery)
+        ("testFilterQuery", testFilterQuery),
+		("testPaginationResponse", testPaginationResponse)
     ]
 }

--- a/Tests/PaginationTests/PaginationTests.swift
+++ b/Tests/PaginationTests/PaginationTests.swift
@@ -19,15 +19,15 @@ final class PaginationTests: XCTestCase {
         super.tearDown()
     }
 
-	func testLinuxTestSuiteIncludesAllTests() {
-		#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-		let thisClass = type(of: self)
-		let linuxCount = thisClass.allTests.count
-		let darwinCount = Int(thisClass
-			.defaultTestSuite.testCaseCount)
-		XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from allTests")
-		#endif
-	}
+    func testLinuxTestSuiteIncludesAllTests() {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        let thisClass = type(of: self)
+        let linuxCount = thisClass.allTests.count
+        let darwinCount = Int(thisClass
+            .defaultTestSuite.testCaseCount)
+        XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from allTests")
+        #endif
+    }
 
     func testQuery() throws {
         let models: [TestModel] = try [
@@ -61,9 +61,9 @@ final class PaginationTests: XCTestCase {
     }
 
     static var allTests = [
-		("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
+        ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
         ("testQuery", testQuery),
         ("testFilterQuery", testFilterQuery),
-		("testPaginationResponse", testPaginationResponse)
+        ("testPaginationResponse", testPaginationResponse)
     ]
 }


### PR DESCRIPTION
I noticed that the test suite was missing a test case in the `allTests` variable used on Linux (testPaginationResponse).
This PR adds the missing test and a new test that will check for missing tests in the `allTests` variable.